### PR TITLE
Fix historical context and networking problems

### DIFF
--- a/src/main/java/ch/endte/syncmatica/Syncmatica.java
+++ b/src/main/java/ch/endte/syncmatica/Syncmatica.java
@@ -68,9 +68,8 @@ public class Syncmatica
         if (contexts == null) {
             contexts = new HashMap<>();
         }
-        if (!contexts.containsKey(contextId)) {
-            contexts.put(contextId, con);
-        }
+        // Always update the context to ensure we have the latest instance (e.g. after re-login)
+        contexts.put(contextId, con);
         context_init = true;
     }
 

--- a/src/main/java/ch/endte/syncmatica/communication/ClientCommunicationManager.java
+++ b/src/main/java/ch/endte/syncmatica/communication/ClientCommunicationManager.java
@@ -81,10 +81,14 @@ public class ClientCommunicationManager extends CommunicationManager
             return;
         }
         if (type.equals(PacketType.REGISTER_VERSION)) {
+            // Reset LitematicManager to clear ghost placements from previous sessions
+            // and ensure it uses the current context.
             LitematicManager.clear();
-            Syncmatica.restartClient();
+            LitematicManager.getInstance().setActiveContext(context);
 
-            ActorClientPlayHandler.getInstance().packetEvent(type, packetBuf);
+            final VersionHandshakeClient hi = new VersionHandshakeClient(server, context);
+            startExchange(hi);
+            hi.handle(type, packetBuf);
         }
     }
 

--- a/src/main/java/ch/endte/syncmatica/communication/exchange/ShareLitematicExchange.java
+++ b/src/main/java/ch/endte/syncmatica/communication/exchange/ShareLitematicExchange.java
@@ -66,6 +66,7 @@ public class ShareLitematicExchange extends AbstractExchange
             redirect.addRedirect(toUpload);
             LitematicManager.getInstance().renderSyncmatic(toShare, schematicPlacement, false);
             getContext().getSyncmaticManager().addPlacement(toShare);
+            succeed();
             return;
         }
         if (type.equals(PacketType.CANCEL_SHARE))

--- a/src/main/java/ch/endte/syncmatica/litematica/LitematicManager.java
+++ b/src/main/java/ch/endte/syncmatica/litematica/LitematicManager.java
@@ -87,6 +87,29 @@ public class LitematicManager
         }
         context = con;
         ScreenHelper.ifPresent(s -> s.setActiveContext(con));
+        context.getSyncmaticManager().addServerPlacementConsumer(this::checkSyncMatches);
+        for (final ServerPlacement p : context.getSyncmaticManager().getAll())
+        {
+            checkSyncMatches(p);
+        }
+    }
+
+    private void checkSyncMatches(final ServerPlacement p)
+    {
+        for (final SchematicPlacement sm : DataManager.getSchematicPlacementManager().getAllSchematicsPlacements())
+        {
+            final UUID smId = eventHandler.getServerId(sm);
+            if (smId != null && smId.equals(p.getId()))
+            {
+                if (!rendering.containsKey(p))
+                {
+                    rendering.put(p, sm);
+                    ((RedirectFileStorage) context.getFileStorage()).addRedirect(sm.getSchematicFile());
+                    readVersionInfo(p, sm);
+                }
+                break;
+            }
+        }
     }
 
     public Context getActiveContext()
@@ -445,6 +468,10 @@ public class LitematicManager
             {
                 final ServerPlacement adjusted = readVersionInfo(p, schem);
                 rendering.put(Objects.requireNonNullElse(adjusted, p), schem);
+                if (context.getFileStorage().getLocalLitematic(p) != schem.getSchematicFile())
+                {
+                    ((RedirectFileStorage) context.getFileStorage()).addRedirect(schem.getSchematicFile());
+                }
                 DataManager.getSchematicPlacementManager().addSchematicPlacement(schem, false);
             }
         }

--- a/src/main/java/ch/endte/syncmatica/litematica/LitematicManager.java
+++ b/src/main/java/ch/endte/syncmatica/litematica/LitematicManager.java
@@ -490,18 +490,21 @@ public class LitematicManager
     public void commitLoad()
     {
         final SyncmaticManager man = context.getSyncmaticManager();
-        for (final SchematicPlacement schem : preLoadList)
+        if (preLoadList != null)
         {
-//            final UUID id = ((IIDContainer) schem).syncmatica$getServerId();
-            final UUID id = eventHandler.getServerId(schem);
-            final ServerPlacement p = man.getPlacement(id);
-            if (p != null)
+            for (final SchematicPlacement schem : preLoadList)
             {
-                if (context.getFileStorage().getLocalLitematic(p) != schem.getSchematicFile())
+//            final UUID id = ((IIDContainer) schem).syncmatica$getServerId();
+                final UUID id = eventHandler.getServerId(schem);
+                final ServerPlacement p = man.getPlacement(id);
+                if (p != null)
                 {
-                    ((RedirectFileStorage) context.getFileStorage()).addRedirect(schem.getSchematicFile());
+                    if (context.getFileStorage().getLocalLitematic(p) != schem.getSchematicFile())
+                    {
+                        ((RedirectFileStorage) context.getFileStorage()).addRedirect(schem.getSchematicFile());
+                    }
+                    renderSyncmatic(p, schem, true);
                 }
-                renderSyncmatic(p, schem, true);
             }
         }
         preLoadList = null;

--- a/src/main/java/ch/endte/syncmatica/network/actor/ActorClientPlayHandler.java
+++ b/src/main/java/ch/endte/syncmatica/network/actor/ActorClientPlayHandler.java
@@ -69,8 +69,12 @@ public class ActorClientPlayHandler
 
     public void packetEvent(final PacketType type, final FriendlyByteBuf data, final ClientPacketListener clientContext, CallbackInfo ci)
     {
-        if (clientCommunication == null)
+        if (clientCommunication == null || exTarget.clientPlayNetworkHandler != clientContext)
         {
+            Syncmatica.debug("ActorClientPlayHandler#packetEvent: re-init client context (communication null: %b, handler mismatch: %b)"
+                    .formatted(clientCommunication == null, exTarget == null || exTarget.clientPlayNetworkHandler != clientContext));
+
+            this.reset();
             ActorClientPlayHandler.getInstance().startEvent(clientContext);
         }
         if (packetEvent(type, data))


### PR DESCRIPTION
Address several critical issues observed in newer Minecraft versions, and make Syncmatica working again on 1.21.11 Fabric server & client. 

Minecraft 1.21.11 has some changes in the client lifecycle (specifically disconnect timing), and that cause Syncmatica to become unresponsive after player rejoining a server.

**Key Changes:**

1. In `Syncmatica.java`, the Context map was not updating if a key already existed, causing the client to use a stale/disconnected session object after rejoining. Now forcibly updates the context map with the fresh instance.
2. The network handler retained a reference to the old `ClientPacketListener` after a reconnect, preventing packets from being sent. Added a check in `ActorClientPlayHandler` to detect connection object mismatches and trigger re-initialization if the underlying connection has changed.
3. An recursive call to `restartClient` during handshake in `ClientCommunicationManager` caused logic loops. Simplified connection reset logic.
4. Also Fixed an issue in `LitematicManager` where existing shared placements were not correctly linked to the file storage system on join/preload. This makes the UI to show "Download" instead of "Unload" and allowing duplicate shares.

**Solves issue:** #31 